### PR TITLE
Re-do mongo CLI execution so it does not use temp files to execute cmds

### DIFF
--- a/module/app/com/scalableminds/mongev/MongevPlugin.scala
+++ b/module/app/com/scalableminds/mongev/MongevPlugin.scala
@@ -184,7 +184,9 @@ private[mongev] trait MongoScriptExecutor extends MongevLogger {
 
   def execute(cmd: String): Option[JsValue] = {
     val processLogger = new StringListLogger
-    val result = startProcess(mongoCmd, s"--quiet <<EOFCMDBBQ\n$cmd\nEOFCMDBBQ") ! (processLogger)
+
+    val stdin = new ByteArrayInputStream(cmd.getBytes("UTF-8"))
+    val result = (startProcess(mongoCmd, "--quiet") #< stdin) ! (processLogger)
 
     val output = processLogger.messages.reverse.mkString("\n")
 

--- a/module/app/com/scalableminds/mongev/MongevPlugin.scala
+++ b/module/app/com/scalableminds/mongev/MongevPlugin.scala
@@ -183,13 +183,8 @@ private[mongev] trait MongoScriptExecutor extends MongevLogger {
   }
 
   def execute(cmd: String): Option[JsValue] = {
-    val input = TemporaryFile("mongo-script", ".js")
-
-    Files.writeFile(input.file, cmd)
-    val jsPath = input.file.getAbsolutePath
-
     val processLogger = new StringListLogger
-    val result = startProcess(mongoCmd, s"--quiet $jsPath") ! (processLogger)
+    val result = startProcess(mongoCmd, s"--quiet <<EOFCMDBBQ\n$cmd\nEOFCMDBBQ") ! (processLogger)
 
     val output = processLogger.messages.reverse.mkString("\n")
 


### PR DESCRIPTION
We were seeing periodic errors running migrations where the mongo CLI was returning exit code 253.  This is an exit code indicating that it couldn't parse the script file in some way or another.

The tricky thing was that the migrations didn't always fail on the same migration.  I suspected that this had to do with some file lock or buffered write ephemeral-ness that was causing these periodic failures.  

The mongo CLI supports providing the mongo commands via standard input without having to write the commands to a temp file at all.  This is the crux of this PR.  